### PR TITLE
filters affect all open tabs when toggling on/off

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
   },
   "permissions": [
     "activeTab",
-    "storage"
+    "storage",
+    "<all_urls>"
   ]
 }

--- a/script/colorblindListener.js
+++ b/script/colorblindListener.js
@@ -5,9 +5,12 @@
  * get the selected filter on popup open
  */
 window.onload = function () {
-    chrome.storage.local.get(['key'], function (result) {
-        document.getElementById(result.key).checked = true;
-    });
+    try {
+        chrome.storage.local.get(['key'], function (result) {
+            document.getElementById(result.key).checked = true;
+        });
+    }
+    catch{ }
 }
 
 /**
@@ -15,79 +18,102 @@ window.onload = function () {
  * @param {String} value the selected input 
  */
 function setSelected(value) {
-    chrome.storage.local.set({ 'key': value }, function () {
-        document.getElementById(value).checked = true;
-    });
+    try {
+        chrome.storage.local.set({ 'key': value }, function () {
+            document.getElementById(value).checked = true;
+        });
+    }
+    catch{ }
 }
 
 //achromatomaly
 document.getElementById("radio-1").addEventListener("click", function () {
     setSelected('radio-1');
-    chrome.tabs.executeScript({
-        file: 'filters/achromatomaly.js'
+    chrome.tabs.query({}, function (tabs) {
+        tabs.forEach(function (tab) {
+            chrome.tabs.executeScript(tab.id, { file: 'filters/achromatomaly.js' });
+        });
     });
+
 });
 
 //achromatopsia
 document.getElementById("radio-2").addEventListener("click", function () {
     setSelected('radio-2');
-    chrome.tabs.executeScript({
-        file: 'filters/achromatopsia.js'
+    chrome.tabs.query({}, function (tabs) {
+        tabs.forEach(function (tab) {
+            chrome.tabs.executeScript(tab.id, { file: 'filters/achromatopsia.js' });
+        });
     });
+
 });
 
 //deuteranomaly
 document.getElementById("radio-3").addEventListener("click", function () {
     setSelected('radio-3');
-    chrome.tabs.executeScript({
-        file: 'filters/deuteranomaly.js'
+    chrome.tabs.query({}, function (tabs) {
+        tabs.forEach(function (tab) {
+            chrome.tabs.executeScript(tab.id, { file: 'filters/deuteranomaly.js' });
+        });
     });
 });
 
 //deuteranopia
 document.getElementById("radio-4").addEventListener("click", function () {
     setSelected('radio-4');
-    chrome.tabs.executeScript({
-        file: 'filters/deuteranopia.js'
+    chrome.tabs.query({}, function (tabs) {
+        tabs.forEach(function (tab) {
+            chrome.tabs.executeScript(tab.id, { file: 'filters/deuteranopia.js' });
+        });
     });
 });
 
 //protanomaly
 document.getElementById("radio-5").addEventListener("click", function () {
     setSelected('radio-5');
-    chrome.tabs.executeScript({
-        file: 'filters/protanomaly.js'
+    chrome.tabs.query({}, function (tabs) {
+        tabs.forEach(function (tab) {
+            chrome.tabs.executeScript(tab.id, { file: 'filters/protanomaly.js' });
+        });
     });
 });
 
 //protanopia
 document.getElementById("radio-6").addEventListener("click", function () {
-    setSelected('radio-5');
-    chrome.tabs.executeScript({
-        file: 'filters/protanopia.js'
+    setSelected('radio-6');
+    chrome.tabs.query({}, function (tabs) {
+        tabs.forEach(function (tab) {
+            chrome.tabs.executeScript(tab.id, { file: 'filters/protanopia.js' });
+        });
     });
 });
 
 //tritanomaly
 document.getElementById("radio-7").addEventListener("click", function () {
-    setSelected('radio-8');
-    chrome.tabs.executeScript({
-        file: 'filters/tritanomaly.js'
+    setSelected('radio-7');
+    chrome.tabs.query({}, function (tabs) {
+        tabs.forEach(function (tab) {
+            chrome.tabs.executeScript(tab.id, { file: 'filters/tritanomaly.js' });
+        });
     });
 });
 
 //tritanopia
 document.getElementById("radio-8").addEventListener("click", function () {
     setSelected('radio-8');
-    chrome.tabs.executeScript({
-        file: 'filters/tritanopia.js'
+    chrome.tabs.query({}, function (tabs) {
+        tabs.forEach(function (tab) {
+            chrome.tabs.executeScript(tab.id, { file: 'filters/tritanopia.js' });
+        });
     });
 });
 
 //normal
 document.getElementById("radio-9").addEventListener("click", function () {
     setSelected('radio-9');
-    chrome.tabs.executeScript({
-        file: 'filters/normal.js'
+    chrome.tabs.query({}, function (tabs) {
+        tabs.forEach(function (tab) {
+            chrome.tabs.executeScript(tab.id, { file: 'filters/normal.js' });
+        });
     });
 });


### PR DESCRIPTION
After hearing feedback from the GitHub community I've decided to have the extension affect all tabs. 

This makes it simpler to toggle all filters on/off and works well with @yonsaber's idea of having the filter selection be persistent after closing the extension window. 

Also deals with errors fetching from storage by wrapping the storage sets/gets in a try catch.