### PR TITLE
Change the CVD simulation matrices to use the more accurate Viénot model

### DIFF
--- a/filters/deuteranomaly.js
+++ b/filters/deuteranomaly.js
@@ -13,7 +13,7 @@ filterID.id = "filterID471924";
 filterID.setAttribute('style', 'height: 0; padding: 0; margin: 0; line-height: 0;');
 document.body.appendChild(filterID);
 
-filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="deuteranomaly"> <feColorMatrix type="matrix" values="0.8,0.2,0,0,0 0.258,0.742,0,0,0 0,0.142,0.858,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
+filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="deuteranomaly" color-interpolation-filters="linearRGB"> <feColorMatrix type="matrix" values="0.57418,0.42582,-0.00000,0,0 0.17418,0.82582,-0.00000,0,0 -0.01318,0.01318,1.00000,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
 stylingID.innerHTML = 'html{-webkit-filter:url(#deuteranomaly);-moz-filter:(#deuteranomaly);-ms-filter:(#deuteranomaly);-o-filter:(#deuteranomaly);filter:(#deuteranomaly);}'
 setTimeout(function() {
     window.scrollBy(1, 1);

--- a/filters/deuteranopia.js
+++ b/filters/deuteranopia.js
@@ -13,7 +13,7 @@ filterID.id = "filterID471924";
 filterID.setAttribute('style', 'height: 0; padding: 0; margin: 0; line-height: 0;');
 document.body.appendChild(filterID);
 
-filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="deuteranopia"> <feColorMatrix type="matrix" values="0.625,0.375,0,0,0 0.7,0.3,0,0,0 0,0.3,0.7,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
+filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="deuteranopia" color-interpolation-filters="linearRGB"> <feColorMatrix type="matrix" values="0.29031,0.70969,-0.00000,0,0 0.29031,0.70969,-0.00000,0,0 -0.02197,0.02197,1.00000,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
 stylingID.innerHTML = 'html{-webkit-filter:url(#deuteranopia);-moz-filter:(#deuteranopia);-ms-filter:(#deuteranopia);-o-filter:(#deuteranopia);filter:(#deuteranopia);}'
 setTimeout(function() {
     window.scrollBy(1, 1);

--- a/filters/protanomaly.js
+++ b/filters/protanomaly.js
@@ -13,7 +13,7 @@ filterID.id = "filterID471924";
 filterID.setAttribute('style', 'height: 0; padding: 0; margin: 0; line-height: 0;');
 document.body.appendChild(filterID);
 
-filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="protanomaly"> <feColorMatrix type="matrix" values="0.817,0.183,0,0,0 0.333,0.667,0,0,0 0,0.125,0.875,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
+filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="protanomaly" color-interpolation-filters="linearRGB"> <feColorMatrix type="matrix" values="0.46533,0.53467,-0.00000,0,0 0.06533,0.93467,0.00000,0,0 0.00268,-0.00268,1.00000,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
 stylingID.innerHTML = 'html{-webkit-filter:url(#protanomaly);-moz-filter:(#protanomaly);-ms-filter:(#protanomaly);-o-filter:(#protanomaly);filter:(#protanomaly);}'
 setTimeout(function() {
     window.scrollBy(1, 1);

--- a/filters/protanopia.js
+++ b/filters/protanopia.js
@@ -13,7 +13,7 @@ filterID.id = "filterID471924";
 filterID.setAttribute('style', 'height: 0; padding: 0; margin: 0; line-height: 0;');
 document.body.appendChild(filterID);
 
-filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="protanopia"> <feColorMatrix type="matrix" values="0.567,0.433,0,0,0 0.558,0.442,0,0,0 0 0.242,0.758,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
+filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="protanopia" color-interpolation-filters="linearRGB"> <feColorMatrix type="matrix" values="0.10889,0.89111,-0.00000,0,0 0.10889,0.89111,0.00000,0,0 0.00447,-0.00447,1.00000,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
 stylingID.innerHTML = 'html{-webkit-filter:url(#protanopia);-moz-filter:(#protanopia);-ms-filter:(#protanopia);-o-filter:(#protanopia);filter:(#protanopia);}'
 setTimeout(function() {
     window.scrollBy(1, 1);

--- a/filters/tritanomaly.js
+++ b/filters/tritanomaly.js
@@ -13,7 +13,7 @@ filterID.id = "filterID471924";
 filterID.setAttribute('style', 'height: 0; padding: 0; margin: 0; line-height: 0;');
 document.body.appendChild(filterID);
 
-filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="tritanomaly"> <feColorMatrix type="matrix" values="0.967,0.033,0,0,0 0,0.733,0.267,0,0 0,0.183,0.817,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
+filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="tritanomaly" color-interpolation-filters="linearRGB"> <feColorMatrix type="matrix" values="1.00000,0.09142,-0.09142,0,0 0.00000,0.92030,0.07970,0,0 -0.00000,0.52030,0.47970,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
 stylingID.innerHTML = 'html{-webkit-filter:url(#tritanomaly);-moz-filter:(#tritanomaly);-ms-filter:(#tritanomaly);-o-filter:(#tritanomaly);filter:(#tritanomaly);}'
 setTimeout(function() {
     window.scrollBy(1, 1);

--- a/filters/tritanopia.js
+++ b/filters/tritanopia.js
@@ -13,7 +13,7 @@ filterID.id = "filterID471924";
 filterID.setAttribute('style', 'height: 0; padding: 0; margin: 0; line-height: 0;');
 document.body.appendChild(filterID);
 
-filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="tritanopia"> <feColorMatrix type="matrix" values="0.95,0.05,0,0,0 0,0.433,0.567,0,0 0,0.475,0.525,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
+filterID.innerHTML = '<svg id="colorblind-filters" style="display: none"> <defs> <filter id="tritanopia" color-interpolation-filters="linearRGB"> <feColorMatrix type="matrix" values="1.00000,0.15236,-0.15236,0,0 0.00000,0.86717,0.13283,0,0 -0.00000,0.86717,0.13283,0,0 0,0,0,1,0" in="SourceGraphic" /> </filter> </defs> </svg>';
 stylingID.innerHTML = 'html{-webkit-filter:url(#tritanopia);-moz-filter:(#tritanopia);-ms-filter:(#tritanopia);-o-filter:(#tritanopia);filter:(#tritanopia);}'
 setTimeout(function() {
     window.scrollBy(1, 1);

--- a/precompute_cvd_matrices.ipynb
+++ b/precompute_cvd_matrices.ipynb
@@ -1,0 +1,138 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "920d306f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ebeb2d46-a94d-4f01-af3f-2b1c6f000b16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io, math, os, sys\n",
+    "from IPython.core.display import HTML\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "# Install daltonlens if necessary\n",
+    "try:\n",
+    "    from daltonlens import convert, simulate\n",
+    "except ImportError:\n",
+    "    !pip install -q daltonlens\n",
+    "    from daltonlens import convert, simulate\n",
+    "\n",
+    "# SVG takes 4x5 matrices for rgba + offset\n",
+    "def printColblindlyMatrix(name, m, severity):\n",
+    "    m = severity*m + (1.0-severity)*np.identity(3)\n",
+    "    print(name)\n",
+    "    print(f\"values=\\\"{m[0,0]:.5f},{m[0,1]:.5f},{m[0,2]:.5f},0,0 {m[1,0]:.5f},{m[1,1]:.5f},{m[1,2]:.5f},0,0 {m[2,0]:.5f},{m[2,1]:.5f},{m[2,2]:.5f},0,0 0,0,0,1,0\\\"\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0420bab",
+   "metadata": {},
+   "source": [
+    "# Introduction\n",
+    "\n",
+    "The goal is to generate the precomputed matrices needed by ColorBlindly, in the linearRGB space. They are meant to be used with `color-interpolation-filters=\"linearRGB\"`.\n",
+    "\n",
+    "The chosen model is Viénot, Brettel and Mollon 1999 _Digital video colourmaps for checking the legibility of displays by dichromats. Color Research & Application_ because it reduces to a single matrix in linear RGB space.\n",
+    "\n",
+    "Anomalous trichromacy is handled via linear interpolation with the original image.\n",
+    "\n",
+    "An alternative with a single matrix would be the Machado 2009 model: https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html \n",
+    "\n",
+    "The Viénot 1999 single matrix model is not great for tritanopia, ideally we'd use the Brettel, Viénot and Mollon 1997 model _Computerized simulation of color appearance for dichromats_. But it requires blending two projection matrices, not sure how we can do this with SVG filters.\n",
+    "\n",
+    "For more information about CVD simulation models, see https://daltonlens.org/opensource-cvd-simulation/ and https://daltonlens.org/understanding-cvd-simulation/ ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "b1ba1b91-cab4-48ba-a27e-919cb404bb6a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "protanopia\n",
+      "values=\"0.10889,0.89111,-0.00000,0,0 0.10889,0.89111,0.00000,0,0 0.00447,-0.00447,1.00000,0,0 0,0,0,1,0\"\n",
+      "\n",
+      "protanomaly\n",
+      "values=\"0.46533,0.53467,-0.00000,0,0 0.06533,0.93467,0.00000,0,0 0.00268,-0.00268,1.00000,0,0 0,0,0,1,0\"\n",
+      "\n",
+      "deuteranopia\n",
+      "values=\"0.29031,0.70969,-0.00000,0,0 0.29031,0.70969,-0.00000,0,0 -0.02197,0.02197,1.00000,0,0 0,0,0,1,0\"\n",
+      "\n",
+      "deuteranomaly\n",
+      "values=\"0.57418,0.42582,-0.00000,0,0 0.17418,0.82582,-0.00000,0,0 -0.01318,0.01318,1.00000,0,0 0,0,0,1,0\"\n",
+      "\n",
+      "tritanopia\n",
+      "values=\"1.00000,0.15236,-0.15236,0,0 0.00000,0.86717,0.13283,0,0 -0.00000,0.86717,0.13283,0,0 0,0,0,1,0\"\n",
+      "\n",
+      "tritanomaly\n",
+      "values=\"1.00000,0.09142,-0.09142,0,0 0.00000,0.92030,0.07970,0,0 -0.00000,0.52030,0.47970,0,0 0,0,0,1,0\"\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "simulator = simulate.Simulator_Vienot1999(convert.LMSModel_sRGB_SmithPokorny75())\n",
+    "\n",
+    "simulator.simulate_cvd(np.zeros((1,1,3), dtype=np.uint8), simulate.Deficiency.PROTAN, severity=1.0)\n",
+    "printColblindlyMatrix(\"protanopia\", simulator.cvd_linear_rgb, 1.0)\n",
+    "printColblindlyMatrix(\"protanomaly\", simulator.cvd_linear_rgb, 0.6)\n",
+    "\n",
+    "simulator.simulate_cvd(np.zeros((1,1,3), dtype=np.uint8), simulate.Deficiency.DEUTAN, severity=1.0)\n",
+    "printColblindlyMatrix(\"deuteranopia\", simulator.cvd_linear_rgb, 1.0)\n",
+    "printColblindlyMatrix(\"deuteranomaly\", simulator.cvd_linear_rgb, 0.6)\n",
+    "\n",
+    "simulator.simulate_cvd(np.zeros((1,1,3), dtype=np.uint8), simulate.Deficiency.TRITAN, severity=1.0)\n",
+    "printColblindlyMatrix(\"tritanopia\", simulator.cvd_linear_rgb, 1.0)\n",
+    "printColblindlyMatrix(\"tritanomaly\", simulator.cvd_linear_rgb, 0.6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdb192cb-f1b8-45ae-abf0-e4a40a9c115d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/script/hover.js
+++ b/script/hover.js
@@ -1,7 +1,7 @@
 const makeCssStyles = type =>
   `#rainbow{-webkit-filter:url(#${type});-moz-filter:(#${type});-ms-filter:(#${type});-o-filter:(#${type});filter:(#${type});}`;
 const makeSVGFilter = (type, filterValues) =>
-  `<svg id="colorblind-filters" style="display: none"> <defs> <filter id="${type}"> <feColorMatrix type="matrix" values="${filterValues}" in="SourceGraphic" /> </filter> </defs> </svg>`;
+  `<svg id="colorblind-filters" style="display: none"> <defs> <filter id="${type}" color-interpolation-filters="linearRGB"> <feColorMatrix type="matrix" values="${filterValues}" in="SourceGraphic" /> </filter> </defs> </svg>`;
 // global to hold the innerhtml of the colorblind filters. each filter has a filterSVG and filterStyles
 const filters = {
   achromatomalySVG: makeSVGFilter(
@@ -18,37 +18,37 @@ const filters = {
 
   deuteranomalySVG: makeSVGFilter(
     "deuteranomaly",
-    "0.8,0.2,0,0,0 0.258,0.742,0,0,0 0,0.142,0.858,0,0 0,0,0,1,0"
+    "0.57418,0.42582,-0.00000,0,0 0.17418,0.82582,-0.00000,0,0 -0.01318,0.01318,1.00000,0,0 0,0,0,1,0"
   ),
   deuteranomalyStyles: makeCssStyles("deuteranomaly"),
 
   deuteranopiaSVG: makeSVGFilter(
     "deuteranopia",
-    "0.625,0.375,0,0,0 0.7,0.3,0,0,0 0,0.3,0.7,0,0 0,0,0,1,0"
+    "0.29031,0.70969,-0.00000,0,0 0.29031,0.70969,-0.00000,0,0 -0.02197,0.02197,1.00000,0,0 0,0,0,1,0"
   ),
   deuteranopiaStyles: makeCssStyles("deuteranopia"),
 
   protanomalySVG: makeSVGFilter(
     "protanomaly",
-    "0.817,0.183,0,0,0 0.333,0.667,0,0,0 0,0.125,0.875,0,0 0,0,0,1,0"
+    "0.46533,0.53467,-0.00000,0,0 0.06533,0.93467,0.00000,0,0 0.00268,-0.00268,1.00000,0,0 0,0,0,1,0"
   ),
   protanomalyStyles: makeCssStyles("protanomaly"),
 
   protanopiaSVG: makeSVGFilter(
     "protanopia",
-    "0.567,0.433,0,0,0 0.558,0.442,0,0,0 0 0.242,0.758,0,0 0,0,0,1,0"
+    "0.10889,0.89111,-0.00000,0,0 0.10889,0.89111,0.00000,0,0 0.00447,-0.00447,1.00000,0,0 0,0,0,1,0"
   ),
   protanopiaStyles: makeCssStyles("protanopia"),
 
   tritanomalySVG: makeSVGFilter(
     "tritanomaly",
-    "0.967,0.033,0,0,0 0,0.733,0.267,0,0 0,0.183,0.817,0,0 0,0,0,1,0"
+    "1.00000,0.09142,-0.09142,0,0 0.00000,0.92030,0.07970,0,0 -0.00000,0.52030,0.47970,0,0 0,0,0,1,0"
   ),
   tritanomalyStyles: makeCssStyles("tritanomaly"),
 
   tritanopiaSVG: makeSVGFilter(
     "tritanopia",
-    "0.95,0.05,0,0,0 0,0.433,0.567,0,0 0,0.475,0.525,0,0 0,0,0,1,0"
+    "1.00000,0.15236,-0.15236,0,0 0.00000,0.86717,0.13283,0,0 -0.00000,0.86717,0.13283,0,0 0,0,0,1,0"
   ),
   tritanopiaStyles: makeCssStyles("tritanopia")
 };


### PR DESCRIPTION
Hi! I've recently been reviewing the CVD simulation models used in opensource software, and it turns out that the currently used ColorMatrix from colorjack.com are very inaccurate. I wrote [a full article about that](https://daltonlens.org/opensource-cvd-simulation/), but in a nutshell these matrices were a quick hack that the author himself recognized to be a very inaccurate approximation of the more complex "HCIRN Color Blind Simulation function". The implementation used in Coblis by [MaPePeR](https://github.com/MaPePeR/jsColorblindSimulator) shows the comment:
>You're right, the ColorMatrix version is very simplified, and not accurate. I created that color matrix one night (http://www.colorjack.com/labs/colormatrix/) and since then it's shown up many places... I should probably take that page down before it spreads more! Anyways, it gives you an idea of what it might look like, but for the real thing...

A more solid reference is the paper of Viénot, Brettel and Mollon in 1999 _Digital video colourmaps for checking the legibility of displays by dichromats_. This is the simulation part used by most daltonization algorithms. The cool thing is that it also reduces to a single 3x3 matrix at the end, so this PR switches to these matrices instead of the ones from colorjack.com.

An important note is that for all these models to be correct we first need to go from the sRGB color space to a linear RGB color space. Fortunately this is easy to enforce for SVG filters with `color-interpolation-filters="linearRGB"`. This PR also adds that.

This Viénot model is pretty good for protanopia and deuteranopia (with all the limits of that kind of simulator of course..), but not great for tritanopia. However none will be great with a single matrix, we'd need to implement for example the Brettel, Viénot and Mollon _Computerized simulation of color appearance for dichromats_ 1997 algorithm for that, but it requires two matrices and a per-pixel dot product test to find out which projection it should use. I'm not very familiar with SVG filters but it does not seem trivial to do, so the Viénot model is probably a reasonable single-matrix fallback.

An alternative to Viénot 1999 would be the [Machado 2009](https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html) algorithm, they also provide single precomputed 3x3 matrices on their website. I picked Viénot in this PR because I'm more familiar with it but the final results will be kind of similar anyway.

I've included a Jupyter notebook to show how I dumped the precomputed values for each deficiency. For the anomalous versions, I picked 0.6 as the severity factor to be close to the original "HCIRN Color Blind Simulation function" code. There is no real justification to pick that number versus another, but I guess it's a reasonable choice to give an idea of what a less severe deficiency would look like.

Hope this helps!